### PR TITLE
Speed and memory improvement

### DIFF
--- a/awesome_align/run_align.py
+++ b/awesome_align/run_align.py
@@ -15,11 +15,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import time
 import argparse
 import random
 import itertools
 import os
+from multiprocessing import Pool, Process, SimpleQueue, cpu_count, Pipe
+import copy
+
 
 import numpy as np
 import torch
@@ -34,7 +37,8 @@ from awesome_align.tokenization_bert import BertTokenizer
 from awesome_align.tokenization_utils import PreTrainedTokenizer
 from awesome_align.modeling_utils import PreTrainedModel
 
-
+def takeFirst(elem):
+    return elem[0]
 
 def set_seed(args):
     if args.seed >= 0:
@@ -43,81 +47,141 @@ def set_seed(args):
         torch.manual_seed(args.seed)
         torch.cuda.manual_seed_all(args.seed)
 
-class LineByLineTextDataset(Dataset):
-    def __init__(self, tokenizer: PreTrainedTokenizer, args, file_path):
-        assert os.path.isfile(file_path)
-        print('Loading the dataset...')
-        self.examples = []
-        with open(file_path, encoding="utf-8") as f:
-            for idx, line in enumerate(f.readlines()):
-                if len(line) == 0 or line.isspace() or not len(line.split(' ||| ')) == 2:
-                    raise ValueError(f'Line {idx+1} is not in the correct format!')
-                
-                src, tgt = line.split(' ||| ')
-                if src.rstrip() == '' or tgt.rstrip() == '':
-                    raise ValueError(f'Line {idx+1} is not in the correct format!')
-            
-                sent_src, sent_tgt = src.strip().split(), tgt.strip().split()
-                token_src, token_tgt = [tokenizer.tokenize(word) for word in sent_src], [tokenizer.tokenize(word) for word in sent_tgt]
-                wid_src, wid_tgt = [tokenizer.convert_tokens_to_ids(x) for x in token_src], [tokenizer.convert_tokens_to_ids(x) for x in token_tgt]
+def insert_sentence_in_batch(idxs, sent_src, sent_tgt, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, sentence):
+    idxs.append(sentence[0])
+    sent_src.append(sentence[1])
+    sent_tgt.append(sentence[2])
+    ids_src.append(sentence[3])
+    ids_tgt.append(sentence[4])
+    bpe2word_map_src.append(sentence[5])
+    bpe2word_map_tgt.append(sentence[6])
 
-                ids_src, ids_tgt = tokenizer.prepare_for_model(list(itertools.chain(*wid_src)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids'], tokenizer.prepare_for_model(list(itertools.chain(*wid_tgt)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids']
-                if len(ids_src[0]) == 2 or len(ids_tgt[0]) == 2:
-                    raise ValueError(f'Line {idx+1} is not in the correct format!')
 
-                bpe2word_map_src = []
-                for i, word_list in enumerate(token_src):
-                    bpe2word_map_src += [i for x in word_list]
-                bpe2word_map_tgt = []
-                for i, word_list in enumerate(token_tgt):
-                    bpe2word_map_tgt += [i for x in word_list]
+def process_encoding(q_data: SimpleQueue, q_preprocessed : SimpleQueue, tokenizer: PreTrainedTokenizer, number_line, nb_preprocess):
+    End = False
+    while End != True:
+        idx, line = q_data.get()
+        if idx >= (number_line-nb_preprocess):
+            #print("C'est la fin de  process encoding")
+            End = True
+        src, tgt = line.split(' ||| ')
+        if src.rstrip() == '' or tgt.rstrip() == '':
+            raise ValueError(f'Line {idx+1} is not in the correct format!')
+    
+        sent_src, sent_tgt = src.strip().split(), tgt.strip().split()
+        token_src, token_tgt = [tokenizer.tokenize(word) for word in sent_src], [tokenizer.tokenize(word) for word in sent_tgt]
+        wid_src, wid_tgt = [tokenizer.convert_tokens_to_ids(x) for x in token_src], [tokenizer.convert_tokens_to_ids(x) for x in token_tgt]
 
-                self.examples.append( (ids_src[0], ids_tgt[0], bpe2word_map_src, bpe2word_map_tgt) )
+        ids_src, ids_tgt = tokenizer.prepare_for_model(list(itertools.chain(*wid_src)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids'], tokenizer.prepare_for_model(list(itertools.chain(*wid_tgt)), return_tensors='pt', max_length=tokenizer.max_len)['input_ids']
+        if len(ids_src[0]) == 2 or len(ids_tgt[0]) == 2:
+            raise ValueError(f'Line {idx+1} is not in the correct format!')
 
-    def __len__(self):
-        return len(self.examples)
+        bpe2word_map_src = []
+        for i, word_list in enumerate(token_src):
+            bpe2word_map_src += [i for x in word_list]
+        bpe2word_map_tgt = []
+        for i, word_list in enumerate(token_tgt):
+            bpe2word_map_tgt += [i for x in word_list]
+        q_preprocessed.put(  (idx, sent_src, sent_tgt, ids_src[0], ids_tgt[0], bpe2word_map_src, bpe2word_map_tgt) )
+    time.sleep(10)
 
-    def __getitem__(self, i):
-        return self.examples[i]
+def feed_data(tokenizer: PreTrainedTokenizer, args, file_path, q_data : SimpleQueue):
+    assert os.path.isfile(file_path)
+    print('Loading the dataset...')
 
-def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer):
+    with open(file_path, encoding="utf-8") as f:
+        for idx, line in enumerate(f.readlines()):
+            if len(line) == 0 or line.isspace() or not len(line.split(' ||| ')) == 2:
+                raise ValueError('Line {idx+1} is not in the correct format!')
+            q_data.put( (idx, line) )
 
-    def collate(examples):
-        ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt = zip(*examples)
+def data_batch(q_preprocessed : SimpleQueue, q_batch, args, tokenizer : PreTrainedTokenizer, number_line):
+    number_batch = args.batch_size
+    current_row = 0
+    End = False
+    tmp_info = [] # Store wrong order sentences
+    while End != True:
+        idxs, sent_src, sent_tgt, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt = ([] for i in range(7))
+        i = 0 
+        while i < args.batch_size:
+            if tmp_info == [] or tmp_info[-1][0] != current_row:
+                sentence = q_preprocessed.get()
+                if sentence[0] != current_row:
+                    tmp_info.append( sentence )
+                    tmp_info.sort(key=takeFirst, reverse=True)
+                else:
+                    i += 1
+                    current_row += 1
+                    insert_sentence_in_batch(idxs, sent_src, sent_tgt, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, sentence)
+            if tmp_info != []:
+                while i < args.batch_size and tmp_info != [] and tmp_info[-1][0] == current_row:
+
+                    if tmp_info[-1][0] == current_row:
+                        sentence = tmp_info.pop()
+                        current_row += 1
+                        i += 1
+                        insert_sentence_in_batch(idxs, sent_src, sent_tgt, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, sentence)
+
+            if current_row == number_line:
+                End = True
+                break                    
+
         ids_src = pad_sequence(ids_src, batch_first=True, padding_value=tokenizer.pad_token_id)
         ids_tgt = pad_sequence(ids_tgt, batch_first=True, padding_value=tokenizer.pad_token_id)
-        return ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt
+        q_batch.send( (idxs, sent_src, sent_tgt, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt) )
+    time.sleep(15)
 
-    dataset = LineByLineTextDataset(tokenizer, args, file_path=args.data_file)
-    sampler = SequentialSampler(dataset)
-    dataloader = DataLoader(
-        dataset, sampler=sampler, batch_size=args.batch_size, collate_fn=collate
-    )
-
+def word_align(args, model: PreTrainedModel, tokenizer: PreTrainedTokenizer, q_batch, number_line, pipe_recovering):
+    End = False
     model.to(args.device)
     model.eval()
-    tqdm_iterator = trange(dataset.__len__(), desc="Extracting")
+    with open(args.output_file, 'w') as writer:
+        with torch.no_grad():
+            while End != True:
+                batch = q_batch.recv()
+                idxs, sent_src, sent_tgt, ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt = batch
+                word_aligns_list = model.get_aligned_word(ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, 0, 0, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold, test=True, output_prob=(args.output_prob_file is not None))
+                pipe_recovering.send( (idxs, sent_src, sent_tgt, word_aligns_list) )
+                if idxs[-1] == number_line-1:
+                    End = True
+
+def file_len(fname):
+    with open(fname) as f:
+        for i, l in enumerate(f):
+            pass
+    return i + 1
+
+def alignement_recovering(p, args, number_line):
+    end = False
+    tqdm_iterator = trange(number_line, desc="Extracting")
     if args.output_prob_file is not None:
         prob_writer = open(args.output_prob_file, 'w')
     with open(args.output_file, 'w') as writer:
-        for batch in dataloader:
-            with torch.no_grad():
-                ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt = batch
-                word_aligns_list = model.get_aligned_word(ids_src, ids_tgt, bpe2word_map_src, bpe2word_map_tgt, args.device, 0, 0, align_layer=args.align_layer, extraction=args.extraction, softmax_threshold=args.softmax_threshold, test=True, output_prob=(args.output_prob_file is not None))
-                for word_aligns in word_aligns_list:
-                    output_str = []
-                    if args.output_prob_file is not None:
-                        output_prob_str = []
-                    for word_align in word_aligns:
+        while end != True:
+            idxs, sent_src, sent_tgt, word_aligns_list = p.recv()
+            output_str = []
+            for idx, word_aligns in enumerate(word_aligns_list):
+                output_str = []
+                if args.output_prob_file is not None:
+                    output_prob_str = []
+                for word_align in word_aligns:
+                    if args.word_output:
+                        output_str.append(f'{sent_src[idx][word_align[0]]}  {sent_tgt[idx][word_align[1]]}')
+                    else:
                         output_str.append(f'{word_align[0]}-{word_align[1]}')
-                        if args.output_prob_file is not None:
-                            output_prob_str.append(f'{word_aligns[word_align]}')
-                    writer.write(' '.join(output_str)+'\n')
                     if args.output_prob_file is not None:
-                        prob_writer.write(' '.join(output_prob_str)+'\n')
-                tqdm_iterator.update(len(ids_src))
-    if args.output_prob_file is not None:
-        prob_writer.close()
+                        output_prob_str.append(f'{word_aligns[word_align]}')
+                if args.word_output:
+                    writer.write('\n'.join(output_str)+'\n')
+                else :
+                    writer.write(' '.join(output_str)+'\n')
+                if args.output_prob_file is not None:
+                    prob_writer.write(' '.join(output_prob_str)+'\n')
+            tqdm_iterator.update(len(idxs))
+            if idxs[-1] == number_line-1:
+                end = True
+
+            
 
 
 def main():
@@ -170,10 +234,11 @@ def main():
         help="Optional directory to store the pre-trained models downloaded from s3 (instead of the default one)",
     )
     parser.add_argument("--no_cuda", action="store_true", help="Avoid using CUDA when available")
+    parser.add_argument("--nb_preprocess", type=int, default=int(cpu_count()/2), help="Number of process that run preprocessing, default = cpu_count / 2")
+    parser.add_argument("--word_output", action="store_true", help="Write align-word in the output")
     args = parser.parse_args()
     device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
     args.device = device
-
     # Set seed
     set_seed(args)
     config_class, model_class, tokenizer_class = BertConfig, BertForMaskedLM, BertTokenizer
@@ -208,7 +273,38 @@ def main():
     else:
         model = model_class(config=config)
 
-    word_align(args, model, tokenizer)
+
+    number_line = file_len(args.data_file)
+    jobs = []
+    q_data = SimpleQueue()
+    q_batch = Pipe()
+    q_preprocessed = SimpleQueue()
+
+    # Creation of preprocessing process 
+    for i in range(args.nb_preprocess):
+        p = Process(target=process_encoding, args=(q_data, q_preprocessed, copy.deepcopy(tokenizer), number_line, args.nb_preprocess))
+        p.start()
+        jobs.append(p)
+
+    # Creation of feed_data process (could change that to a thread but it's not faster)
+    p = Process(target=feed_data, args=(tokenizer, args, args.data_file, q_data))
+    p.start()
+    jobs.append(p)
+    p = Process(target=data_batch, args=(q_preprocessed, q_batch[1], args, copy.deepcopy(tokenizer), number_line))
+    p.start()
+    jobs.append(p)
+    #alignement_recovering, (could change that to a thread but it's not faster)
+    pipe = Pipe()
+    p = Process(target=alignement_recovering, args=(pipe[0], args, number_line))
+    p.start()
+    jobs.append(p)
+
+    #Run word, alignement
+    word_align(args, model, tokenizer, q_batch[0], number_line, pipe[1])
+
+
+    for process in jobs:
+        process.join()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi,
Here is a speed improvement up to 50%, and a requested RAM size of a fixed amount (10GB aprox.)

This merge request change a lot of things in run_align.py

The starting point was to observe that the preprocessing was running, single-threaded, while not using the gpu and increasing the RAM needed proportionally to the size of the input_file.

The main idea in this version is to do in the same time preprocessing and alignment. This improve the memory management because the result are immediately written, using no more memory. And improve the speed because of this parallelization.

1) The memory size is not fixed, this was causing me issue for file with more than 3 millions sentences (needed 32GB of RAM), now it needs only 10GB for every size of file, this is of course a drawback for small size, but you can downsize the ram needed with the new parameters `--nb_preprocess`, I personally recommend at least 2-3 for this option.
2) The time for preprocessing was approximately 50% of the global time, so this time is now remove, improving the speed by this factor.

In more details :
We have a lot of process : 
 -feed_data : read the data, and put all sentences in a queue for process_encoding
-process_encoding : make the preprocessing of the data (several of them)
-data_batch : reorder the sentences to get the same output and feed batch to word_align
-word_align : run alignement then give all sentences to alignement_recovering
-alignement_recovering : this write in the ouput_file the result

word_align and alignement_recovering are split because it's improve the alignement speed by 10%

Here is a benchmark on my computeur (RTX3090, I9-7920X, 32GB 2666Mhz) for 1 millions sentences : 
- old run_align : 1h9min
- new run_align (5 preprocess) : 37 min

Improvements to be made : 
- When process are done, they are waiting 15 second because of a strange error, I couldn't resolve, resulting the queue object to be corrupted as soon as one process finish.
- On both script my RTX3090 translate at 700 sentences/sec for the first 15 000 before droping performance to 450 on avg. I couldn't find the reason plus the graphic card only run to 70% of its capacity, very strange
- If you use the cpu, with the new script, the performance are similar, but they can be improve with a second alignement process because it uses only half of the cpu power. 

Finally, I add `--word_output`, in order to get a tab separate file with the word and the alignement. It was usefull to my application (building a probabilistic dictionnary)

If you have any comment, or idea of improvement please let me know, it's my first ever pull-request on open source repo.

