### PR TITLE
update gitignore to include files produced by pip install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+awesome_align.egg-info
+build
+dist
+cache


### PR DESCRIPTION
pip install will produce files that won't have to be included in this repo, so I think it's better to add them to git ignore. The cache here could be a place to put cached models.